### PR TITLE
ECOMMONS-1673

### DIFF
--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -99,7 +99,8 @@
 
     <ds-generic-item-page-field [item]="object"
                                 [fields]="['dc.description']"
-                                [label]="'item.page.description'">
+                                [label]="'item.page.description'"
+                                [separator]="'<br/><br/>'">
     </ds-generic-item-page-field>
 
     <ds-generic-item-page-field [item]="object"
@@ -196,7 +197,8 @@
     </ds-item-page-uri-field>
     <ds-generic-item-page-field [item]="object"
                                 [fields]="['dc.relation']"
-                                [label]="'Related To'">
+                                [label]="'Related To'"
+                                [separator]="'<br/><br/>'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="object"
                                 [fields]="['dc.relation.haspart']"
@@ -220,7 +222,8 @@
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="object"
                                 [fields]="['dc.relation.isreferencedby']"
-                                [label]="'Related Publication(s)'">
+                                [label]="'Related Publication(s)'"
+                                [separator]="'<br/><br/>'">
     </ds-generic-item-page-field>
     <ds-item-page-uri-field [item]="object"
                             [fields]="['dc.relation.isreferencedbyuri']"


### PR DESCRIPTION
adds `<br><br>` to separate multiple instances of dc.relation, dc.relation.isreferencedby and dc.description on simple view