### PR TITLE
ECOMMONS-1674 modifies help links on header and footer

### DIFF
--- a/src/themes/ecommons/app/footer/footer.component.html
+++ b/src/themes/ecommons/app/footer/footer.component.html
@@ -1,7 +1,7 @@
 <footer class="text-lg-start">
     <div class="container">
         <div *ngIf="showTopFooter" class="top-footer">
-            <p class="help-link"><a href="/statistics">Site Statistics</a> | <a href="https://guides.library.cornell.edu/ecommons/search">Help</a></p>
+            <p class="help-link"><a href="/statistics">Site Statistics</a> | <a href="https://guides.library.cornell.edu/ecommons">Help</a></p>
             <p><a href="http://guides.library.cornell.edu/ecommons">About eCommons</a> | <a href="http://guides.library.cornell.edu/ecommons/policy">Policies</a> | <a href="http://guides.library.cornell.edu/ecommons/terms">Terms of use</a> | <a href="/info/feedback">Contact Us</a></p>
         </div>
 

--- a/src/themes/ecommons/app/header/header.component.html
+++ b/src/themes/ecommons/app/header/header.component.html
@@ -28,7 +28,7 @@
         <ds-themed-search-navbar></ds-themed-search-navbar>
         <ds-lang-switch></ds-lang-switch>
         <div class="header-link pl-2 pr-2 d-none d-sm-block">
-          <a href="https://guides.library.cornell.edu/ecommons/search">
+          <a href="https://guides.library.cornell.edu/ecommons">
             Help
           </a>
         </div>


### PR DESCRIPTION
Modifies help links on header and footer to point to parent ecommons help page instead of search

from Erica - I’m wondering if we can change the links that “help” directs to (top and bottom right of eC homepage) to the parent guide page https://guides.library.cornell.edu/ecommons instead of the search guidance. The system keeps throwing errors and I need to get patrons to the troubleshooting guidance.